### PR TITLE
Add numbered quotes

### DIFF
--- a/lemonHope.py
+++ b/lemonHope.py
@@ -25,7 +25,6 @@ def isAlreadyRemembered(table, author, msg):
 async def saveQuote(table, author, message, sendResponse):
     if not isAlreadyRemembered(table, author, message):
         table.insert({'name': author, 'message': message})
-        print(sendResponse)
         await sendResponse('Remembered that ' + author + ' said ' + message)
 
 
@@ -81,13 +80,14 @@ async def remember(ctx, *, arg):
 @lemon.command()
 async def quote(ctx, *arg):
     quotepocket = getDBFromGuild(str(ctx.message.guild)).table('quote')
+    msg = None
     if len(arg) == 0:
         msg = random.choice(quotepocket.all())
-        await ctx.send('<' + msg['name'] + '> ' + msg['message'])
     else:
         query = Query()
         msg = random.choice(quotepocket.search(query.name.matches('.*' + arg[0] + '.*', flags=re.IGNORECASE)))
-        await ctx.send('<' + msg['name'] + '> ' + msg['message'])
+
+    await ctx.send('<' + msg['name'] + '> ' + msg['message'])
 
 
 lemon.run(token)

--- a/lemonHope.py
+++ b/lemonHope.py
@@ -15,10 +15,17 @@ lemon = commands.Bot(command_prefix="Lemon, ")
 
 
 def getDBFromGuild(guild):
+    """
+    Retrieves db from guild name
+    """
     return TinyDB(r'data/' + guild + r'.json')
 
 
 def isAlreadyRemembered(table, author, msg):
+    """
+    Determines if a quote already exists
+    Returns None or quote document id
+    """
     query = Query()
     results = table.search(query.name.matches('.*' + author + '.*', flags=re.IGNORECASE) and query.message == msg)
 
@@ -33,17 +40,27 @@ def isAlreadyRemembered(table, author, msg):
 
 
 async def saveQuote(table, author, message, sendResponse):
-    # qid is overloaded - but it gets the job done cleanly
+    """
+    saveQuote to db
+    sendResponse is the send function from discord
+    """
+    # qid is overloaded - but it gets the job done
     qid = isAlreadyRemembered(table, author, message)
     if not qid:
         qid = table.insert({'name': author, 'message': message})
     await sendResponse('Remembered that ' + author + ' said "' + message + '" (#' + str(qid) + ')')
 
+
 def getInt(s):
+    """
+    Get int - helper function
+    Returns int or None
+    """
     try:
         return int(s)
     except ValueError:
         return None
+
 
 @lemon.event
 async def on_reaction_add(ctx, user):
@@ -76,7 +93,6 @@ async def remember(ctx, *, arg):
 
     messages = await channel.history(limit=50).flatten()
     quotepocket = getDBFromGuild(str(ctx.message.guild)).table('quote')
-
 
     for ms in messages:
         if name in ms.author.name.lower() and (findString in ms.content.lower() or not findString) and "Lemon, " not in ms.content:

--- a/lemonHope.py
+++ b/lemonHope.py
@@ -51,9 +51,9 @@ async def on_reaction_add(ctx, user):
 async def remember(ctx, *, arg):
     split = arg.split(' ')
 
-    name = split[0]
+    name = split[0].lower()
     channel = ctx.message.channel
-    findString = ''.join(split[1:])
+    findString = ''.join(split[1:]).lower()
     found = False
 
     print('Saving quote from ' + name + ' via text command')
@@ -63,7 +63,7 @@ async def remember(ctx, *, arg):
 
 
     for ms in messages:
-        if name in ms.author.name and (findString in ms.content or not findString) and "Lemon, " not in ms.content:
+        if name in ms.author.name.lower() and (findString in ms.content.lower() or not findString) and "Lemon, " not in ms.content:
             lock = asyncio.Lock()
             await lock.acquire()
             try:

--- a/lemonHope.py
+++ b/lemonHope.py
@@ -1,10 +1,11 @@
-import random
-import os
-from discord.ext import commands
-from tinydb import TinyDB, Query
-from dotenv import load_dotenv
 import asyncio
+import os
+import random
 import re
+
+from discord.ext import commands
+from dotenv import load_dotenv
+from tinydb import TinyDB, Query
 
 print('Lemon is starting')
 load_dotenv()
@@ -27,7 +28,11 @@ async def saveQuote(table, author, message, sendResponse):
         table.insert({'name': author, 'message': message})
         await sendResponse('Remembered that ' + author + ' said "' + message + '"')
 
-
+def getInt(s):
+    try:
+        return int(s)
+    except ValueError:
+        return None
 
 @lemon.event
 async def on_reaction_add(ctx, user):
@@ -83,11 +88,16 @@ async def quote(ctx, *arg):
     msg = None
     if len(arg) == 0:
         msg = random.choice(quotepocket.all())
+    elif getInt(arg[0]):
+        msg = quotepocket.get(doc_id=getInt(arg[0]))
     else:
         query = Query()
         msg = random.choice(quotepocket.search(query.name.matches('.*' + arg[0] + '.*', flags=re.IGNORECASE)))
 
-    await ctx.send('<' + msg['name'] + '> ' + msg['message'])
+    if msg:
+        await ctx.send('<' + msg['name'] + '> ' + msg['message'])
+    else:
+        await ctx.send('Couldn\'t find that quote')
 
 
 lemon.run(token)

--- a/lemonHope.py
+++ b/lemonHope.py
@@ -25,7 +25,7 @@ def isAlreadyRemembered(table, author, msg):
 async def saveQuote(table, author, message, sendResponse):
     if not isAlreadyRemembered(table, author, message):
         table.insert({'name': author, 'message': message})
-        await sendResponse('Remembered that ' + author + ' said ' + message)
+        await sendResponse('Remembered that ' + author + ' said "' + message + '"')
 
 
 
@@ -74,7 +74,7 @@ async def remember(ctx, *, arg):
             found = True
             break
     if not found:
-        await ctx.send('Could not find a message from ' + name + ' containing ' + findString)
+        await ctx.send('Could not find a message from ' + name + ' containing "' + findString + '"')
 
 
 @lemon.command()

--- a/lemonHope.py
+++ b/lemonHope.py
@@ -6,6 +6,7 @@ from dotenv import load_dotenv
 import asyncio
 import re
 
+print('Lemon is starting')
 load_dotenv()
 token = os.getenv('lemonhope_token')
 
@@ -21,41 +22,56 @@ def isAlreadyRemembered(table, author, msg):
     return any(table.search(query.name.matches('.*' + author + '.*', flags=re.IGNORECASE) and query.message == msg))
 
 
+async def saveQuote(table, author, message, sendResponse):
+    if not isAlreadyRemembered(table, author, message):
+        table.insert({'name': author, 'message': message})
+        print(sendResponse)
+        await sendResponse('Remembered that ' + author + ' said ' + message)
+
+
+
 @lemon.event
-async def on_reaction_add(reaction, user):
-    if str(reaction.emoji) == '💬' and not any(r.me is True for r in reaction.message.reactions):
-        await reaction.message.add_reaction('💬')
+async def on_reaction_add(ctx, user):
+    if str(ctx.emoji) == '💬' and not any(r.me is True for r in ctx.message.reactions):
+        print('Saving quote from ' + ctx.message.author.name + ' via reaction')
+
         lock = asyncio.Lock()
+        quotepocket = getDBFromGuild(str(ctx.message.guild)).table('quote')
+
         await lock.acquire()
         try:
-            quotepocket = getDBFromGuild(str(reaction.message.guild)).table('quote')
-            if not isAlreadyRemembered(quotepocket, reaction.message.author.name, reaction.message.content):
-                quotepocket.insert({'name': reaction.message.author.name, 'message': reaction.message.content})
-                await reaction.message.channel.send(
-                    'Remembered that ' + reaction.message.author.name + ' said ' + reaction.message.content)
+            await saveQuote(
+                    quotepocket, ctx.message.author.name, ctx.message.content, ctx.message.channel.send)
         finally:
             lock.release()
+
+        await ctx.message.add_reaction('💬')
 
 
 @lemon.command()
 async def remember(ctx, *, arg):
     split = arg.split(' ')
+
     name = split[0]
     channel = ctx.message.channel
     findString = ''.join(split[1:])
-    messages = await channel.history(limit=50).flatten()
     found = False
+
+    print('Saving quote from ' + name + ' via text command')
+
+    messages = await channel.history(limit=50).flatten()
     quotepocket = getDBFromGuild(str(ctx.message.guild)).table('quote')
+
+
     for ms in messages:
         if name in ms.author.name and (findString in ms.content or not findString) and "Lemon, " not in ms.content:
             lock = asyncio.Lock()
             await lock.acquire()
             try:
-                if not isAlreadyRemembered(quotepocket, ms.author.name, ms.content):
-                    quotepocket.insert({'name': ms.author.name, 'message': ms.content})
-                    await ctx.send('Remembered that ' + ms.author.name + ' said "' + ms.content + '"!')
+                await saveQuote(quotepocket, ms.author.name, ms.content, ctx.send)
             finally:
                 lock.release()
+
             found = True
             break
     if not found:


### PR DESCRIPTION
Quotes can now be searched by number `Lemon, quote 1`. Quote numbers are also displayed when adding. Additionally, when a quote has already been added, it will display a message like it's being newly added, with the existing id.

This change is rebased on #2 and relies on it - or can be merged ignored it.