### PR TITLE
feat(conversions): add mph/kmh speed conversions and full-word distance aliases

### DIFF
--- a/conversions/utils.py
+++ b/conversions/utils.py
@@ -170,6 +170,22 @@ def convertKilometerToMiles(kilometer: float) -> Tuple[float, str]:
     return (kilometer / 1.609344, 'mi')
 
 
+def convertMphToKmh(mph: float) -> Tuple[float, str]:
+    """
+    Converts miles per hour to kilometers per hour
+    Return (kmh, unit)
+    """
+    return (mph * 1.609344, 'kmh')
+
+
+def convertKmhToMph(kmh: float) -> Tuple[float, str]:
+    """
+    Converts kilometers per hour to miles per hour
+    Return (mph, unit)
+    """
+    return (kmh / 1.609344, 'mph')
+
+
 def notImplemented():
 
     """
@@ -188,5 +204,11 @@ CONVERSION_MAP = {
     'ft': convertFeetToMeter,
     'm': convertMeterToFeet,
     'km': convertKilometerToMiles,
-    'mi': convertMilesToKilometer
+    'kilometers': convertKilometerToMiles,
+    'mi': convertMilesToKilometer,
+    'miles': convertMilesToKilometer,
+    'mph': convertMphToKmh,
+    'mi/h': convertMphToKmh,
+    'kmh': convertKmhToMph,
+    'km/h': convertKmhToMph
 }


### PR DESCRIPTION
### Description
- Added `convertMphToKmh` and `convertKmhToMph` conversion functions
- Registered speed unit aliases in `CONVERSION_MAP`: `mph`, `mi/h`, `kmh`, `km/h`
- Added full-word distance aliases: `miles` and `kilometers` (pointing to existing conversion
functions)

---

**Stack**:
- #45
- #44 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*