### PR TITLE
feat(conversions): add comma formatting to conversion output numbers

### DIFF
--- a/conversions/utils.py
+++ b/conversions/utils.py
@@ -52,7 +52,7 @@ def buildConvertionStr(ogTuple: Tuple[str, float], convTuple: Tuple[str, float])
     ogVal = formatFloat(ogVal, floatPrecision)
 
 
-    return messageTemplate.format(ogVal=ogVal, ogUnit=ogUnit, convVal=convVal, convUnit=convUnit)
+    return messageTemplate.format(ogVal=f'{ogVal:,}', ogUnit=ogUnit, convVal=f'{convVal:,}', convUnit=convUnit)
 
 def getConversionTupleFromMessage(msg: str) -> List[Tuple[str, float]]:
     """


### PR DESCRIPTION
### Description
Format large numbers in conversion output with comma separators for readability (e.g. `2,000,000mph
is 3,218,688kmh` instead of `2000000mph is 3218688kmh`).

Uses Python's built-in `,` format spec, which handles both integers and floats correctly.

---

**Stack**:
- #45 ⬅
- #44


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*